### PR TITLE
Initial commit, moved gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/coverage/*
+/.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
+require 'simplecov'
+
+gem 'simplecov', require: false, group: :test
+
 source 'https://rubygems.org'
 
 gem 'cane'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,50 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    cane (3.0.0)
+      parallel
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    kwalify (0.7.2)
+    parallel (1.22.1)
+    parser (3.1.2.1)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    reek (6.1.1)
+      kwalify (~> 0.7.0)
+      parser (~> 3.1.0)
+      rainbow (>= 2.0, < 4.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+
+PLATFORMS
+  x86_64-darwin-21
+
+DEPENDENCIES
+  cane
+  rake
+  reek
+  rspec
+  simplecov
+
+BUNDLED WITH
+   2.3.23

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'simplecov'


### PR DESCRIPTION
Moved .gitignore from a sub-directory to the root black_thursday directory

Added coverage and bundle to gitignore, neither was pushed to github on commit and push

When pulled down to local, the gitignore file will be included and will be enabled on local directories. This should prevent the upload of the coverage files