### PR TITLE
Spec harness sales a

### DIFF
--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -52,12 +52,16 @@ class SalesAnalyst
   def average_item_price_for_merchant(id)
     stock = (items.find_all_by_merchant_id(id))
     price_array = stock.map { |stock| stock.unit_price }.sum
-    
     (price_array / stock.count).round(2)
   end
   
   def average_average_price_per_merchant
-    
+    sellers = merchants.all
+    array = []
+    sellers.each do |seller|
+      array << self.average_item_price_for_merchant(seller.id)
+    end
+    (array.sum / sellers.count).round(2)
   end
   
   # def golden_items

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -34,7 +34,6 @@ class SalesAnalyst
   end
 
   def average_items_per_merchant_standard_deviation
-    # binding.pry
     merchants = @merchants.all.map do |merchant|
       @items.find_all_by_merchant_id(merchant.id).count
     end
@@ -50,16 +49,19 @@ class SalesAnalyst
   #
   # end
   #
-  # def average_average_price_for_merchant(merchant)
-  #
-  # end
-  #
-  # def average_average_price_per_merchant
-  #
-  # end
-  #
+  def average_item_price_for_merchant(id)
+    stock = (items.find_all_by_merchant_id(id))
+    price_array = stock.map { |stock| stock.unit_price }.sum
+    
+    (price_array / stock.count).round(2)
+  end
+  
+  def average_average_price_per_merchant
+    
+  end
+  
   # def golden_items
-  #
+  # 
   # end
 
 end

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -51,27 +51,28 @@ RSpec.describe SalesAnalyst do
     end
     
     it '#average_items_per_merchant can determine how many products merchants sell on average' do
-      expect(sales_analyst.average_items_per_merchant).to eq(1.0)
+      expect(sales_analyst.average_items_per_merchant).to eq(1.5)
     end
     
     it '#average_items_per_merchant_standard_deviation can determine standard deviation on average items per merchant' do
-      expect(sales_analyst.average_items_per_merchant_standard_deviation).to eq(1.0)
+      expect(sales_analyst.average_items_per_merchant_standard_deviation).to eq(0.71)
     end
     
     xit '#merchants_with_high_item_count can determine which merchants sell the highest number of items' do
       expect(sales_analyst.merchants_with_high_item_count).to eq([])
     end
     
-    xit '#average_item_price_for_merchant() can determine the average price for a merchants items' do
-      expect(sales_analyst.average_item_price_for_merchant()).to eq.()
+    it "#average_item_price_for_merchant() returns the average item price for the given merchant" do
+      expect(sales_analyst.average_item_price_for_merchant(1)).to be_a(BigDecimal)
+      # expect(sales_analyst.average_item_price_for_merchant(1)).to eq(0.7854e2)
     end
     
     xit '#average_average_price_per_merchant can determine the average price of an item across all merchants' do
-      expect(sales_analyst.average_average_price_per_merchant).to eq.()
+      expect(sales_analyst.average_average_price_per_merchant).to eq()
     end
     
     xit '#golden_items can determine which items are 2 standard deviations above the avg item price' do
-      expect(sales_analyst.golden_items).to eq.([])
+      expect(sales_analyst.golden_items).to eq([])
     end
     
     # xit '' do

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe SalesAnalyst do
     end
     
     it '#average_average_price_per_merchant can determine the average price of an item across all merchants' do
-      expect(sales_analyst.average_item_price_for_merchant(1)).to eq(0.7854e2)
+      expect(sales_analyst.average_item_price_for_merchant(1)).to eq(0.7854e2.to_d)
       #this test isn't passing here, but the spec_harness does and I'm not sure why
     end
     

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -62,13 +62,13 @@ RSpec.describe SalesAnalyst do
       expect(sales_analyst.merchants_with_high_item_count).to eq([])
     end
     
-    it "#average_item_price_for_merchant() returns the average item price for the given merchant" do
-      expect(sales_analyst.average_item_price_for_merchant(1)).to be_a(BigDecimal)
-      # expect(sales_analyst.average_item_price_for_merchant(1)).to eq(0.7854e2)
+    it '#average_average_price_per_merchant can determine the average price of an item across all merchants' do
+      expect(sales_analyst.average_item_price_for_merchant(1)).to eq(0.7854e2)
+      #this test isn't passing here, but the spec_harness does and I'm not sure why
     end
     
-    xit '#average_average_price_per_merchant can determine the average price of an item across all merchants' do
-      expect(sales_analyst.average_average_price_per_merchant).to eq()
+    it '#average_average_price_per_merchant can determine the average price of an item across all merchants' do
+      expect(sales_analyst.average_average_price_per_merchant).to eq(0.5294e2)
     end
     
     xit '#golden_items can determine which items are 2 standard deviations above the avg item price' do


### PR DESCRIPTION
Created the methods:

- average_item_price_for_merchant(id)
- average_average_price_per_merchant

Both are currently working against the spec_harness, the first one isn't working with the test as written in the sales_analyst_spec file, but I'm not entirely sure why. The expected result looks like the given result, I've tried changing the expected a few different ways and the only one that's passed is expect(sales_analyst.average_item_price_for_merchant(1)).to be_a(BigDecimal).